### PR TITLE
`objects/<stix_id>/report` now returns full report instead of report-id 

### DIFF
--- a/dogesec_commons/objects/db_view_creator.py
+++ b/dogesec_commons/objects/db_view_creator.py
@@ -36,6 +36,11 @@ FILTER_FIELDS_EDGE = [
     "relationship_type",
     "_stix2arango_note",
 ]
+FILTER_SCO_FIELDS = [
+    "name",
+    "value",
+    "number",
+]
 FILTER_FIELDS = list(set(FILTER_FIELDS_EDGE + FILTER_FIELDS_VERTEX))
 
 
@@ -59,7 +64,7 @@ def create_view(db: StandardDatabase, view_name):
 
     try:
         return db.create_arangosearch_view(
-            view_name, {"primarySort": primary_sort, "storedValues": [FILTER_FIELDS]}
+            view_name, {"primarySort": primary_sort, "storedValues": [SORT_FIELDS, FILTER_FIELDS_VERTEX, FILTER_FIELDS_EDGE]}
         )
     except arango.exceptions.ViewCreateError as e:
         logging.error(e)

--- a/dogesec_commons/objects/helpers.py
+++ b/dogesec_commons/objects/helpers.py
@@ -429,10 +429,15 @@ class ArangoDBHelper:
             "id": id,
         }
         query = """
-            FOR doc in @@view
-            FILTER doc.id == @id
+            LET report_ids = (
+                FOR doc in @@view
+                FILTER doc.id == @id
+                RETURN DISTINCT doc._stixify_report_id
+            )
+            FOR report in @@view
+            FILTER report.type == 'report' AND report.id IN report_ids
             LIMIT @offset, @count
-            RETURN DISTINCT doc._stixify_report_id
+            RETURN KEEP(report, KEYS(report, TRUE))
         """
         return self.execute_query(query, bind_vars=bind_vars)
     

--- a/dogesec_commons/objects/views.py
+++ b/dogesec_commons/objects/views.py
@@ -199,7 +199,19 @@ class SingleObjectView(viewsets.ViewSet):
     
 @extend_schema_view(
     reports=extend_schema(
-        responses=ArangoDBHelper.get_paginated_response_schema('reports', {'type': 'string'}),
+        responses=ArangoDBHelper.get_paginated_response_schema(
+            'reports', {
+                "type": "object",
+                "properties": {
+                    "type":{
+                        "example": "report",
+                    },
+                    "id": {
+                        "example": "report--a86627d4-285b-5358-b332-4e33f3ec1075",
+                    },
+                },
+                "additionalProperties": True,
+            }),
         parameters=ArangoDBHelper.get_schema_operation_parameters() + [QueryParams.object_id_param],
         summary="Get all Reports that references STIX ID",
         description=textwrap.dedent(

--- a/dogesec_commons/stixifier/views.py
+++ b/dogesec_commons/stixifier/views.py
@@ -157,6 +157,7 @@ class ExtractorsView(txt2stixView):
         )
     ]
     pagination_class = Pagination("extractors")
+    filter_backends = [DjangoFilterBackend]
 
 
     class filterset_class(FilterSet):


### PR DESCRIPTION
closes #26