### PR TITLE
deduplicate `/objects/[smo|sco|sdo]s/` endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dogesec_commons"
-version = "0.0.6"
+version = "0.0.7-rc0"
 authors = [
   { name="DOGESEC", email="noreply@dogesec.com" },
 ]


### PR DESCRIPTION
- deduplicate smos, sros, sdos
- add extra data to s2a uploads
- use post/file id in s2a_note

needed to fix https://github.com/muchdogesec/obstracts/issues/158